### PR TITLE
Add .configloader filtering to DirSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,31 @@ In practice this means:
 
 This makes nested overlays behave as expected, including inside `map[string]struct`-like configurations.
 
+### DirSource file filtering
+
+`DirSource` only considers files that look like config, so it can safely point at a directory that also holds other files (e.g. a git repo root with a README, `.gitignore`, etc.).
+
+By default, only `*.yml` and `*.yaml` files are loaded.
+Subdirectories are always skipped.
+
+You can customize this per-directory by adding a `.configloader` file alongside your config files:
+
+```yaml
+include:
+  - "*.yml"
+  - "*.yaml"
+  - "*.json"
+exclude:
+  - "*.local.yml"
+```
+
+* `include` is a whitelist: if present, it replaces the built-in default entirely, and only files matching one of its patterns are eligible
+* `exclude` is a blacklist: it removes files from whatever `include` (or the default) already selected
+* a file must match `include` **and** not match `exclude` to be loaded — the two lists are independent, not a single ordered gitignore-style list
+* patterns are plain [`filepath.Match`](https://pkg.go.dev/path/filepath#Match) globs matched against the file's base name, not its full path
+* `.configloader` itself is always skipped, and does not need to be valid YAML for merging — it's only read as filter configuration, never passed through the merge step
+* a `.configloader` file that fails to parse causes `Load` to return an error, rather than silently falling back to defaults
+
 ### Unmarshaling source documents
 
 By default, [`YamlUnmarshal`](./pkg/config/config.go) is used to decode each source into an intermediate document.

--- a/pkg/config/dirsource.go
+++ b/pkg/config/dirsource.go
@@ -7,11 +7,41 @@ import (
 
 	"github.com/pastdev/configloader/pkg/log"
 	"github.com/rs/zerolog"
+	"gopkg.in/yaml.v3"
 )
+
+// configloaderFile is the name of the optional control file, read from a
+// DirSource's directory, that governs which files in that directory are
+// eligible for loading. It is always skipped as a config file itself.
+const configloaderFile = ".configloader"
+
+// defaultIncludes is the glob pattern set used to select files when a
+// directory has no .configloader file, or has one that doesn't specify
+// Include.
+var defaultIncludes = []string{"*.yml", "*.yaml"}
+
+// DirSourceControl is the schema for the optional .configloader file. When
+// present in a DirSource's directory, it governs which files in that
+// directory are eligible for loading, in addition to the built-in defaults.
+type DirSourceControl struct {
+	// Include is the set of glob patterns (matched with filepath.Match
+	// against a file's base name) a file must satisfy at least one of to be
+	// eligible for loading. If nil, the built-in default of "*.yml" and
+	// "*.yaml" is used. If non-nil (including an empty list), it entirely
+	// replaces the built-in default.
+	Include []string `yaml:"include"`
+	// Exclude is a set of glob patterns, matched the same way as Include,
+	// that remove files from the eligible set even if they matched Include.
+	Exclude []string `yaml:"exclude"`
+}
 
 // DirSource is a directory containing config files to load. The files within
 // the directory will be processed in order, sorted by filename, with later
 // values overriding existing values.
+//
+// Which files are considered is governed by an optional .configloader file
+// in the directory (see DirSourceControl). Without one, only *.yml and
+// *.yaml files are considered.
 type DirSource struct {
 	Path string
 	// Unmarshal is the function to unmarshal the data from each file in the
@@ -28,9 +58,24 @@ func (s DirSource) Load(merge Merger) error {
 		return nil
 	}
 
+	control, err := loadDirSourceControl(dir)
+	if err != nil {
+		return fmt.Errorf("load control: %w", err)
+	}
+
+	includes := control.Include
+	if includes == nil {
+		includes = defaultIncludes
+	}
+
 	files := zerolog.Arr()
 	for _, entry := range listing {
-		name := entry.Name()
+		entryName := entry.Name()
+		if entryName == configloaderFile {
+			continue
+		}
+
+		name := entryName
 		if !entry.Type().IsRegular() {
 			if entry.IsDir() {
 				log.Logger.Debug().
@@ -58,6 +103,18 @@ func (s DirSource) Load(merge Merger) error {
 			name = entry.Name()
 		}
 
+		eligible, err := dirSourceEligible(entryName, includes, control.Exclude)
+		if err != nil {
+			return fmt.Errorf("filter: %w", err)
+		}
+		if !eligible {
+			log.Logger.Debug().
+				Str("dir", dir).
+				Str("file", entryName).
+				Msg("skipping filtered file")
+			continue
+		}
+
 		file := filepath.Join(dir, name)
 		//nolint:gosec // intent is to allow user specified config directory/file
 		b, err := os.ReadFile(file)
@@ -83,4 +140,57 @@ func (s DirSource) Load(merge Merger) error {
 
 func (s DirSource) String() string {
 	return fmt.Sprintf("dirsource:%s", s.Path)
+}
+
+// loadDirSourceControl reads and parses the .configloader file from dir, if
+// present. A missing file is not an error; it results in a zero-value
+// DirSourceControl, which selects the built-in default include patterns.
+func loadDirSourceControl(dir string) (DirSourceControl, error) {
+	//nolint:gosec // intent is to allow user specified config directory/file
+	b, err := os.ReadFile(filepath.Join(dir, configloaderFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DirSourceControl{}, nil
+		}
+		return DirSourceControl{}, fmt.Errorf("read %s: %w", configloaderFile, err)
+	}
+
+	var control DirSourceControl
+	err = yaml.Unmarshal(b, &control)
+	if err != nil {
+		return DirSourceControl{}, fmt.Errorf("unmarshal %s: %w", configloaderFile, err)
+	}
+	return control, nil
+}
+
+// dirSourceEligible reports whether name is eligible for loading: it must
+// match at least one include pattern, and must not match any exclude
+// pattern.
+func dirSourceEligible(name string, includes, excludes []string) (bool, error) {
+	included, err := dirSourceMatchAny(name, includes)
+	if err != nil {
+		return false, err
+	}
+	if !included {
+		return false, nil
+	}
+
+	excluded, err := dirSourceMatchAny(name, excludes)
+	if err != nil {
+		return false, err
+	}
+	return !excluded, nil
+}
+
+func dirSourceMatchAny(name string, patterns []string) (bool, error) {
+	for _, pattern := range patterns {
+		matched, err := filepath.Match(pattern, name)
+		if err != nil {
+			return false, fmt.Errorf("match pattern %q: %w", pattern, err)
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/config/dirsource_test.go
+++ b/pkg/config/dirsource_test.go
@@ -1,0 +1,113 @@
+//nolint:goconst // explicit strings have explanatory value in tests
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pastdev/configloader/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirSourceLoad(t *testing.T) {
+	tester := func(t *testing.T, files map[string]string, expected map[any]any) {
+		LoadTester[map[any]any]{
+			Files: files,
+			Sources: []config.SourceLoader{
+				config.DirSource{Path: "app"},
+			},
+		}.Test(t, expected, map[any]any{})
+	}
+
+	errorTester := func(t *testing.T, files map[string]string) {
+		dir := t.TempDir()
+		for name, content := range files {
+			err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0600)
+			require.NoError(t, err)
+		}
+
+		err := (config.DirSource{Path: dir}).Load(func(any) {})
+		require.Error(t, err)
+	}
+
+	t.Run("default ignores non yaml files", func(t *testing.T) {
+		tester(t,
+			map[string]string{
+				"app/config.yml": `{"foo":"bar"}`,
+				// leading * is a yaml alias indicator, so this would fail
+				// to parse if DirSource ever attempted to unmarshal it
+				"app/.gitignore": "*.swp\n",
+				"app/README.md":  "# not yaml\njust prose\n",
+			},
+			map[any]any{"foo": "bar"},
+		)
+	})
+
+	t.Run("configloader widens include", func(t *testing.T) {
+		tester(t,
+			map[string]string{
+				"app/config.yml": `{"foo":"bar","hip":"hop"}`,
+				"app/zzz.json":   `{"foo":"baz"}`,
+				"app/.configloader": `
+include:
+  - "*.yml"
+  - "*.json"
+`,
+			},
+			map[any]any{"foo": "baz", "hip": "hop"},
+		)
+	})
+
+	t.Run("configloader narrows via exclude", func(t *testing.T) {
+		tester(t,
+			map[string]string{
+				"app/config.yml":       `{"foo":"bar","hip":"hop"}`,
+				"app/config.local.yml": `{"foo":"baz"}`,
+				"app/.configloader": `
+exclude:
+  - "*.local.yml"
+`,
+			},
+			map[any]any{"foo": "bar", "hip": "hop"},
+		)
+	})
+
+	t.Run("include and exclude are and'd", func(t *testing.T) {
+		tester(t,
+			map[string]string{
+				"app/config.yml":       `{"foo":"bar","hip":"hop"}`,
+				"app/config.local.yml": `{"foo":"baz"}`,
+				"app/notes.txt":        "not yaml, not eligible either way\n",
+				"app/.configloader": `
+include:
+  - "*.yml"
+exclude:
+  - "*.local.yml"
+`,
+			},
+			map[any]any{"foo": "bar", "hip": "hop"},
+		)
+	})
+
+	t.Run("configloader excludes itself even when include matches everything", func(t *testing.T) {
+		tester(t,
+			map[string]string{
+				"app/config.yml": `{"foo":"bar"}`,
+				"app/notes.txt":  `{"other":"value"}`,
+				"app/.configloader": `
+include:
+  - "*"
+`,
+			},
+			map[any]any{"foo": "bar", "other": "value"},
+		)
+	})
+
+	t.Run("malformed configloader is an error", func(t *testing.T) {
+		errorTester(t, map[string]string{
+			"config.yml":    `{"foo":"bar"}`,
+			".configloader": "not: [valid",
+		})
+	})
+}


### PR DESCRIPTION
DirSource previously attempted to YAML-parse every regular file in a directory, which breaks when the directory also contains non-config files (e.g. a git repo root with README.md/.gitignore). Default to only *.yml/*.yaml files, and allow an optional .configloader file to widen or narrow that set via independent include/exclude globs.